### PR TITLE
chore: Include instructions for running app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A Habitica client built on redux
 ## Installation
 
 ```bash
-npm install -g webpack gulp
 npm install
 ```
 
-## Running the application
+## Building Assets
 
 ```bash
-gulp
+npm start
 ```
 
-open the `index.html` file in `./build` folder. There is currently no static/dev server.
+## Running the App
+
+Open the `index.html` file in `./build` folder. There is currently no static/dev server.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Habitica front-end",
   "main": "index.js",
   "scripts": {
+    "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
closes #8 

Prevents the need to install gulp and webpack globally.
